### PR TITLE
fix: duplicated removing high iou layouts when scores are equal

### DIFF
--- a/magic_pdf/model/magic_model.py
+++ b/magic_pdf/model/magic_model.py
@@ -68,8 +68,10 @@ class MagicModel:
         for model_page_info in self.__model_list:
             need_remove_list = []
             layout_dets = model_page_info['layout_dets']
-            for layout_det1 in layout_dets:
-                for layout_det2 in layout_dets:
+            for i in range(len(layout_dets)):
+                for j in range(i + 1, len(layout_dets)):
+                    layout_det1 = layout_dets[i]
+                    layout_det2 = layout_dets[j]
                     if layout_det1 == layout_det2:
                         continue
                     if layout_det1['category_id'] in [


### PR DESCRIPTION
在magic_pdf/model/magic_model.py:__fix_by_remove_high_iou_and_low_confidence函数中，函数的逻辑是对于high iou的两个layout，只保留score较高的一个。由于magic_pdf的原代码的实现在score相等时有问题，而monkey把所有score都设为了1，因而这个函数实际上没有正常发挥作用，而总是把两个layout都删除了。
具体可见我在mineru的pr：https://github.com/opendatalab/MinerU/pull/2831