### PR TITLE
feat: allow custom weight paths for PP-DocLayout_plus-L

### DIFF
--- a/docs/install_paddlex.md
+++ b/docs/install_paddlex.md
@@ -37,4 +37,17 @@ Update the `model` field in the [`model_configs.yaml`](https://github.com/Yulian
 layout_config: 
   model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
 ```
-> 💡 Note: The model weights will be downloaded automatically the first time you run the program.  No manual download is required.
+
+Model weights will be automatically downloaded to the default Hugging Face path the first time you run the program.
+
+To manually download and store PP-DocLayout_plus-L weight files in your configured models_dir directory, execute the following procedure:
+
+1. Download PP-DocLayout_plus-L weights to your local `models_dir` directory
+2. Add the following configuration to your [`model_configs.yaml`](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/model_configs.yaml) file:
+```yaml
+weights:
+  PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L # The relative path of models_dir
+
+layout_config: 
+  model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
+```

--- a/docs/install_paddlex.md
+++ b/docs/install_paddlex.md
@@ -27,7 +27,8 @@ Execute the following command to install the base version of PaddleX.
 ```bash
 pip install "paddlex[base]"
 ```
-> ❗ **Note**
+> [!NOTE]
+> 
 > If the installation methods above are not suitable for your environment, or if you wish to explore more options, please refer to the official **[PaddleX](https://github.com/PaddlePaddle/PaddleX)**.
 ### **2.  Modify the Configuration File**
 
@@ -37,17 +38,18 @@ Update the `model` field in the [`model_configs.yaml`](https://github.com/Yulian
 layout_config: 
   model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
 ```
-
-Model weights will be automatically downloaded to the default Hugging Face path the first time you run the program.
-
-To manually download and store PP-DocLayout_plus-L weight files in your configured models_dir directory, execute the following procedure:
-
-1. Download PP-DocLayout_plus-L weights to your local `models_dir` directory
-2. Add the following configuration to your [`model_configs.yaml`](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/model_configs.yaml) file:
-```yaml
-weights:
-  PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L # The relative path of models_dir
-
-layout_config: 
-  model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
-```
+> [!TIP]
+> 
+> Model weights will be automatically downloaded to the default HuggingFace path the first time you run the program.
+> 
+> To manually download and store PP-DocLayout_plus-L weight files in your configured models_dir directory, execute the following procedure:
+> 
+> 1. Download PP-DocLayout_plus-L weights to your local `models_dir` directory (link: [ModelScope](https://modelscope.cn/models/PaddlePaddle/PP-DocLayout_plus-L),[HuggingFace](https://huggingface.co/PaddlePaddle/PP-DocLayout_plus-L))
+> 2. Add the following configuration to your [`model_configs.yaml`](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/model_configs.yaml) file:
+> ```yaml
+> weights:
+>   PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L # The relative path of models_dir
+> 
+> layout_config: 
+>   model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
+> ```

--- a/docs/install_paddlex.md
+++ b/docs/install_paddlex.md
@@ -30,6 +30,7 @@ pip install "paddlex[base]"
 > [!NOTE]
 > 
 > If the installation methods above are not suitable for your environment, or if you wish to explore more options, please refer to the official **[PaddleX](https://github.com/PaddlePaddle/PaddleX)**.
+
 ### **2.  Modify the Configuration File**
 
 Update the `model` field in the [`model_configs.yaml`](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/model_configs.yaml#L7) file at the project root to `PP-DocLayout_plus-L`.

--- a/magic_pdf/model/custom_model.py
+++ b/magic_pdf/model/custom_model.py
@@ -67,10 +67,13 @@ class MonkeyOCR:
                 device=self.device,
             )
         elif self.layout_model_name == MODEL_NAME.PaddleXLayoutModel:
+            layout_model_path = None
+            if self.layout_model_name in self.configs['weights']:
+                layout_model_path = os.path.join(models_dir, self.configs['weights'][self.layout_model_name])
             self.layout_model = atom_model_manager.get_atom_model(
                 atom_model_name=AtomicModel.Layout,
                 layout_model_name=MODEL_NAME.PaddleXLayoutModel,
-                paddlex_model_name=MODEL_NAME.PaddleXLayoutModel,
+                paddlexlayout_model_dir=layout_model_path,
                 device=self.device,
             )
         logger.info(f'layout model loaded: {self.layout_model_name}')

--- a/magic_pdf/model/sub_modules/layout/paddlex_layout/PaddleXLayoutModel.py
+++ b/magic_pdf/model/sub_modules/layout/paddlex_layout/PaddleXLayoutModel.py
@@ -1,6 +1,7 @@
 import numpy as np
 from PIL import Image
 from typing import List, Union
+from loguru import logger
 
 from magic_pdf.config.ocr_content_type import CategoryId
 
@@ -11,10 +12,16 @@ except ImportError:
 
 
 class PaddleXLayoutModelWrapper:
-    def __init__(self, model_name: str, device: str):
+    def __init__(self, model_name: str, device: str, model_dir: str = None):
         self.model_name = model_name
         self.device = device  # Note: Device may not be directly used by paddlex.create_model
-        self.model = create_model(model_name=self.model_name)
+        logger.info(f"Loading {self.model_name} model from {model_dir}...")
+        if model_dir is not None:
+            self.model_dir = model_dir
+            self.model = create_model(model_name=self.model_name, model_dir=self.model_dir)
+        else:
+            self.model = create_model(model_name=self.model_name)
+
         self.category_mapping = {
             "paragraph_title": CategoryId.Title,
             "image": CategoryId.ImageBody,

--- a/magic_pdf/model/sub_modules/model_init.py
+++ b/magic_pdf/model/sub_modules/model_init.py
@@ -4,6 +4,7 @@ from loguru import logger
 from magic_pdf.config.constants import MODEL_NAME
 from magic_pdf.model.model_list import AtomicModel
 
+
 def doclayout_yolo_model_init(weight, device='cpu'):
     from magic_pdf.model.sub_modules.layout.doclayout_yolo.DocLayoutYOLO import \
         DocLayoutYOLOModel
@@ -12,11 +13,13 @@ def doclayout_yolo_model_init(weight, device='cpu'):
     model = DocLayoutYOLOModel(weight, device)
     return model
 
-def paddex_layout_model_init(model_name: str, device: str):
+
+def paddex_layout_model_init(device: str, model_dir: str = None):
     from magic_pdf.model.sub_modules.layout.paddlex_layout.PaddleXLayoutModel import \
         PaddleXLayoutModelWrapper
-    model = PaddleXLayoutModelWrapper(model_name=model_name, device=device)
+    model = PaddleXLayoutModelWrapper(model_name=MODEL_NAME.PaddleXLayoutModel, device=device, model_dir=model_dir)
     return model
+
 
 class AtomModelSingleton:
     _instance = None
@@ -40,6 +43,7 @@ class AtomModelSingleton:
             self._models[key] = atom_model_init(model_name=atom_model_name, **kwargs)
         return self._models[key]
 
+
 def atom_model_init(model_name: str, **kwargs):
     atom_model = None
     if model_name == AtomicModel.Layout:
@@ -50,7 +54,7 @@ def atom_model_init(model_name: str, **kwargs):
             )
         elif kwargs.get('layout_model_name') == MODEL_NAME.PaddleXLayoutModel:
             atom_model = paddex_layout_model_init(
-                model_name=kwargs.get('paddlex_model_name'),
+                model_dir=kwargs.get('paddlexlayout_model_dir'),
                 device=kwargs.get('device')
             )
         else:

--- a/model_configs.yaml
+++ b/model_configs.yaml
@@ -1,16 +1,16 @@
 device: cuda # cuda / cpu / mps (using `transformers` as backend)
 weights:
   doclayout_yolo: Structure/doclayout_yolo_docstructbench_imgsz1280_2501.pt # or Structure/layout_zh.pt
-  PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L # The relative path of models_dir
+  PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L
   layoutreader: Relation
 models_dir: model_weight
 layout_config: 
-  model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
+  model: doclayout_yolo # PP-DocLayout_plus-L / doclayout_yolo
   reader:
     name: layoutreader
 chat_config:
   weight_path: model_weight/Recognition
-  backend: transformers # lmdeploy / vllm / transformers / api / lmdeploy_queue / vllm_queue
+  backend: lmdeploy # lmdeploy / vllm / transformers / api / lmdeploy_queue / vllm_queue
   batch_size: 10 # active when using `transformers` as backend
   # if using xxx_queue as backend
   queue_config:

--- a/model_configs.yaml
+++ b/model_configs.yaml
@@ -1,15 +1,16 @@
 device: cuda # cuda / cpu / mps (using `transformers` as backend)
 weights:
   doclayout_yolo: Structure/doclayout_yolo_docstructbench_imgsz1280_2501.pt # or Structure/layout_zh.pt
+  PP-DocLayout_plus-L: Structure/PP-DocLayout_plus-L # The relative path of models_dir
   layoutreader: Relation
 models_dir: model_weight
 layout_config: 
-  model: doclayout_yolo # PP-DocLayout_plus-L / doclayout_yolo
+  model: PP-DocLayout_plus-L # PP-DocLayout_plus-L / doclayout_yolo
   reader:
     name: layoutreader
 chat_config:
   weight_path: model_weight/Recognition
-  backend: lmdeploy # lmdeploy / vllm / transformers / api / lmdeploy_queue / vllm_queue
+  backend: transformers # lmdeploy / vllm / transformers / api / lmdeploy_queue / vllm_queue
   batch_size: 10 # active when using `transformers` as backend
   # if using xxx_queue as backend
   queue_config:


### PR DESCRIPTION
adds support for custom weight paths for the PP-DocLayout_plus-L model, allowing users to specify local model weights instead of relying solely on automatic downloads from Hugging Face or other.