### PR TITLE
handle the pdf page with rotation

### DIFF
--- a/magic_pdf/data/dataset.py
+++ b/magic_pdf/data/dataset.py
@@ -564,7 +564,7 @@ class Doc(PageableData):
             overlay=overlay,
         )
 
-    def insert_text(self, coord, content, fontsize, color):
+    def insert_text(self, coord, content, fontsize, color, rotate):
         """insert text.
 
         Args:
@@ -572,5 +572,6 @@ class Doc(PageableData):
             content (str): the text content
             fontsize (int): font size of the text
             color (list[float] | None):  three element tuple which describe the RGB of the board line, None will use the default font color!
+            rotate (int): the rotation of the text, None means no rotation
         """
-        self._doc.insert_text(coord, content, fontsize=fontsize, color=color)
+        self._doc.insert_text(coord, content, fontsize=fontsize, color=color, rotate=rotate)

--- a/magic_pdf/libs/draw_bbox.py
+++ b/magic_pdf/libs/draw_bbox.py
@@ -14,7 +14,7 @@ def draw_bbox_without_number(i, bbox_list, page, rgb_config, fill_config):
     page_data = bbox_list[i]
     for bbox in page_data:
         x0, y0, x1, y1 = bbox
-        rect_coords = fitz.Rect(x0, y0, x1, y1)  # Define the rectangle
+        rect_coords = fitz.Rect(x0, y0, x1, y1) * page.derotation_matrix  # Define the rectangle
         if fill_config:
             page.draw_rect(
                 rect_coords,
@@ -43,7 +43,7 @@ def draw_bbox_with_number(i, bbox_list, page, rgb_config, fill_config, draw_bbox
     page_data = bbox_list[i]
     for j, bbox in enumerate(page_data):
         x0, y0, x1, y1 = bbox
-        rect_coords = fitz.Rect(x0, y0, x1, y1)  # Define the rectangle
+        rect_coords = fitz.Rect(x0, y0, x1, y1) * page.derotation_matrix  # Define the rectangle
         if draw_bbox:
             if fill_config:
                 page.draw_rect(
@@ -64,7 +64,7 @@ def draw_bbox_with_number(i, bbox_list, page, rgb_config, fill_config, draw_bbox
                     overlay=True,
                 )  # Draw the rectangle
         page.insert_text(
-            (x1 + 2, y0 + 10), str(j + 1), fontsize=10, color=new_rgb
+            (rect_coords.x1 + 2, rect_coords.y0 + 10), str(j + 1), fontsize=10, color=new_rgb, rotate=page.rotation,
         )  # Insert the index in the top left corner of the rectangle
 
 


### PR DESCRIPTION
感谢您们开源这么优秀的项目！
# Summary
  [解决因为pdf页面被旋转后，*_layout.pdf出现矩形框与实际内容不对齐的问题。这些问题在MinerU中也会出现[https://github.com/opendatalab/MinerU/issues/1020](url)、[https://github.com/opendatalab/MinerU/issues/304](url)、[https://github.com/opendatalab/MinerU/issues/251](url)等。
# 测试pdf
 
[potracelib_origin.pdf](https://github.com/user-attachments/files/21364111/potracelib_origin.pdf)
# 结果对比
修复后的效果：
<img width="1141" height="838" alt="bea8ea9a-78f6-4920-a752-1489ad8c7952" src="https://github.com/user-attachments/assets/c8bd2bb1-5bde-413e-827d-a195267bfdb6" />
修改前的效果：
<img width="1014" height="781" alt="6d3d7b4d-6cba-48de-a117-f10b8452d5c6" src="https://github.com/user-attachments/assets/e6b1ef6f-7e11-44eb-9ab6-0d1de27742c8" />

