### PR TITLE
Fix image display issues in markdown files from /parse and /parse/split APIs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -624,7 +624,7 @@ async def create_zip_file_async(result_dir, zip_path, original_name, split_pages
                                 if filename_part.startswith('images/'):
                                     # Handle images: page_0/images/img.jpg -> page_0/images/original_name_img.jpg
                                     img_name = filename_part.replace('images/', '')
-                                    new_filename = f"{page_dir}/images/{original_name}_{img_name}"
+                                    new_filename = f"{page_dir}/images/{img_name}"
                                 else:
                                     # Handle other files in page directories
                                     new_filename = f"{page_dir}/{original_name}_{filename_part}"
@@ -651,7 +651,7 @@ async def create_zip_file_async(result_dir, zip_path, original_name, split_pages
                             if 'images/' in rel_path:
                                 # Keep images in images subfolder with original name prefix
                                 image_name = os.path.basename(rel_path)
-                                new_filename = f"images/{original_name}_{image_name}"
+                                new_filename = f"images/{image_name}"
                             else:
                                 new_filename = f"{original_name}_{filename}"
                     


### PR DESCRIPTION
# Fix image display issues in markdown files from /parse and /parse/split APIs

## Description

The /parse and /parse/split endpoints add filename prefixes when creating images in the zip file's images directory, but the reference paths in the markdown files are not updated accordingly, causing the markdown files to fail to load images properly. 

## Solution

Remove the prefixes from images in the zip file's images directory to match the reference paths in markdown files.

## Changes

- Fixed image path inconsistency between markdown references and actual image filenames
- Affects both `/parse` and `/parse/split` API endpoints