### PR TITLE
Fix invalid escape sequence syntax warning.

### DIFF
--- a/magic_pdf/operators/pipes_llm.py
+++ b/magic_pdf/operators/pipes_llm.py
@@ -43,7 +43,7 @@ class PipeResultLLM:
         md_content = union_make(
             pdf_info_list, md_make_mode, drop_mode, img_dir_or_bucket_prefix
         )
-        return md_content.replace('\$', '$').replace('\*', '*').replace('<seg>', '\<seg\>').replace('<sos', '\<sos\>').replace('<eos>', '\<eos\>').replace('<pad>', '\<pad\>').replace('<unk>', '\<unk\>').replace('<sep>', '\<sep\>').replace('<cls>', '\<cls\>')
+        return md_content.replace('\\$', '$').replace('\\*', '*').replace('<seg>', r'\<seg\>').replace('<sos', r'\<sos\>').replace('<eos>', r'\<eos\>').replace('<pad>', r'\<pad\>').replace('<unk>', r'\<unk\>').replace('<sep>', r'\<sep\>').replace('<cls>', r'\<cls\>')
 
     def dump_md(
         self,

--- a/magic_pdf/operators/pipes_llm.py
+++ b/magic_pdf/operators/pipes_llm.py
@@ -43,7 +43,7 @@ class PipeResultLLM:
         md_content = union_make(
             pdf_info_list, md_make_mode, drop_mode, img_dir_or_bucket_prefix
         )
-        return md_content.replace('\\$', '$').replace('\\*', '*').replace('<seg>', r'\<seg\>').replace('<sos', r'\<sos\>').replace('<eos>', r'\<eos\>').replace('<pad>', r'\<pad\>').replace('<unk>', r'\<unk\>').replace('<sep>', r'\<sep\>').replace('<cls>', r'\<cls\>')
+        return md_content.replace('\\$', '$').replace('\\*', '*').replace('<seg>', r'\<seg\>').replace('<sos>', r'\<sos\>').replace('<eos>', r'\<eos\>').replace('<pad>', r'\<pad\>').replace('<unk>', r'\<unk\>').replace('<sep>', r'\<sep\>').replace('<cls>', r'\<cls\>')
 
     def dump_md(
         self,


### PR DESCRIPTION
Hi, I'm using Debian 13 Trixie, `3.13.5` is the curret Python version of it, and I got warning message like this:

```
magic_pdf/operators/pipes_llm.py:46: SyntaxWarning: invalid escape sequence '\$'
  return md_content.replace('\$', '$').replace('\*', '*').replace('<seg>', '\<seg\>').replace('<sos', '\<sos\>').replace('<eos>', '\<eos\>').replace('<pad>', '\<pad\>').replace('<unk>', '\<unk\>').replace('<sep>', '\<sep\>').replace('<cls>', '\<cls\>')
```

So this PR is to fix that warning, it's not error but I think this will be helpful for future use.