### PR TITLE
Fix deprecated chat template name.

### DIFF
--- a/magic_pdf/model/custom_model.py
+++ b/magic_pdf/model/custom_model.py
@@ -172,7 +172,7 @@ class MonkeyChat_LMDeploy:
                               "to use MonkeyChat_LMDeploy.")
         self.model_name = os.path.basename(model_path)
         self.engine_config = self._auto_config_dtype(dp=dp, tp=tp)
-        self.pipe = pipeline(model_path, backend_config=self.engine_config, chat_template_config=ChatTemplateConfig('qwen2d5-vl'))
+        self.pipe = pipeline(model_path, backend_config=self.engine_config, chat_template_config=ChatTemplateConfig(model_path))
         self.gen_config=GenerationConfig(max_new_tokens=4096,do_sample=True,temperature=0,repetition_penalty=1.05)
 
     def _auto_config_dtype(self, dp=1, tp=1):
@@ -527,7 +527,7 @@ class MonkeyChat_LMDeploy_queue:
         self.pipe = pipeline(
             model_path, 
             backend_config=self.engine_config, 
-            chat_template_config=ChatTemplateConfig('qwen2d5-vl')
+            chat_template_config=ChatTemplateConfig(model_path)
         )
         
         self.gen_config = GenerationConfig(


### PR DESCRIPTION
Hi, `qwen2d5-vl` is a deprecated chat template name now, it will cause error on latest LMDeploy like this:

```
ERROR    | __main__:<module>:14 - Server failed to start: Try apply_chat_template failed: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: ''.
```

Just fixed it :)