### PR TITLE
fix: resolve segmentation fault in fitz.open

### DIFF
--- a/magic_pdf/data/dataset.py
+++ b/magic_pdf/data/dataset.py
@@ -382,7 +382,7 @@ class MultiFileDataset(Dataset):
             raise RuntimeError("No valid files were processed")
         
         # Get the final PDF bytes
-        self._data_bits = pdf_doc.tobytes()
+        self._data_bits = pdf_doc.tobytes(deflate=True)
         pdf_doc.close()
         
         # Reopen the PDF for processing


### PR DESCRIPTION
## 问题：
`MultiFileDataset` 处理大批量 PDF 时因数据过大会导致 `fitz.open` 发生 `Segmentation fault`。
<img width="928" height="296" alt="3f5275e75af5b854f675487bf4833fdd" src="https://github.com/user-attachments/assets/fa2e21c5-a978-4181-aa40-b2cfe643bf35" />


## 解决方法：
通过启用 `tobytes(deflate=True)` 对合并数据进行无损压缩，降低内存占用从而避免崩溃。
同一批pdf压缩前后内存大小对比（3.3G -> 299M）：
<img width="250" height="34" alt="8b97db3c2483ba85612c40c83b800b51" src="https://github.com/user-attachments/assets/e9fc9bd0-347f-4dd0-ab04-d6a59242b818" />

